### PR TITLE
Handle Tn5-overlaps in buildmolecules. 

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -144,7 +144,7 @@ rule tagbam:
             "samtools addreplacerg"
             " -O BAM"
             " -r ID:1"
-            " -r LB:lib1"
+            " -r LB:{config[library_type]}"
             " -r PU:unit1"
             " -r SM:20"
             " -r PL:ILLUMINA"

--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -20,10 +20,12 @@ def main(args):
 
     # Build molecules from BCs and reads
     with pysam.AlignmentFile(args.input, "rb") as infile:
+        library_type = infile.header.to_dict()["RG"][0]["LB"]
         bc_to_mol_dict, header_to_mol_dict = build_molecules(pysam_openfile=infile,
                                                              barcode_tag=args.barcode_tag,
                                                              window=args.window,
                                                              min_reads=args.threshold,
+                                                             tn5=library_type == "blr",
                                                              summary=summary)
     # Writes filtered out
     with PySAMIO(args.input, args.output, __name__) as (openin, openout):
@@ -81,7 +83,7 @@ def parse_reads(pysam_openfile, barcode_tag, summary):
             summary["Non analyced reads"] += 1
 
 
-def build_molecules(pysam_openfile, barcode_tag, window, min_reads, summary):
+def build_molecules(pysam_openfile, barcode_tag, window, min_reads, tn5, summary):
     """
     Builds all_molecules.bc_to_mol ([barcode][moleculeID] = molecule) and
     all_molecules.header_to_mol ([read_name]=mol_ID)
@@ -89,6 +91,7 @@ def build_molecules(pysam_openfile, barcode_tag, window, min_reads, summary):
     :param barcode_tag: Tag used to store barcode in bam file.
     :param window: Max distance between reads to include in the same molecule.
     :param min_reads: Minimum reads to include molecule in all_molecules.bc_to_mol
+    :param tn5: boolean. Library is constructed using Tn5 transposase and has possible 9-bp overlaps.
     :param summary: dict for stats collection
     :return: dict[barcode][molecule] = moleculeInstance, dict[read_name] = mol_ID
     """
@@ -112,7 +115,13 @@ def build_molecules(pysam_openfile, barcode_tag, window, min_reads, summary):
             # Read is within window => add read to molecule (don't include overlapping reads).
             if (molecule.stop + window) >= read_start:
                 if molecule.stop >= read_start and read.query_name not in molecule.read_headers:
-                    summary["Overlapping reads in molecule"] += 1
+                    # If tn5 was used for library construction, overlaps of ~9 bp are accepted.
+                    if tn5 and 8 <= molecule.stop - read_start <= 10:
+                        summary["Tn5-overlapping reads"] += 1
+                        molecule.add_read(stop=read_stop, read_header=read.query_name)
+                        all_molecules.cache_dict[barcode] = molecule
+                    else:
+                        summary["Overlapping reads in molecule"] += 1
                 else:
                     molecule.add_read(stop=read_stop, read_header=read.query_name)
                     all_molecules.cache_dict[barcode] = molecule

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -34,7 +34,7 @@ blr config \
 pushd outdir-bowtie2
 blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == e3d636a7fa3516f223a69ec01056b422
+test $m == d3974efe2eedbb6e4cd5fc19792183f1
 
 # Cut away columns 2 and 3 as these change order between linux and osx
 m2=$(cut -f1,4- mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase | md5sum | cut -f1 -d" ")


### PR DESCRIPTION
Added ability to include Tn5 type overlaps for blr libraries. see issue #50. Tn5 overlap defined as being between 8-10 bp i.e. (9+/-1bp). In the test dataset this incompased 320/520 overlapps. Also updated RG-tag info with the `library_type` from the config file. 